### PR TITLE
feat(convert-unit): Allow to convert units to different formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ $ npm install koa-server-timing
 ```js
 const Koa = require('koa');
 const app = new Koa();
-app.use(require('koa-server-timing')({ total: true /* default to NODE_ENV !== 'production' */ }));
+app.use(require('koa-server-timing')({
+  total: true, /* default to NODE_ENV !== 'production' */
+  convertMetricUnit: time => time * 1000, /* default to time => time */
+}));
 
 ctx.state.timings.startSpan('A Task description', 'taskSlug' /* optional, will be created a-task-description, if missed */)
 
@@ -34,6 +37,7 @@ ctx.state.timings.stopSpan('A Task description' /* or 'taskSlug' or return from 
 ### Options
 
 * `total` where do you want to see total processing time in Server-Timings
+* `convertMetricUnit` in what format do you want the serverTimings metrics? (default is seconds)
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,13 @@ function getSlug(str) {
   return str.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z-]/g, '');
 }
 
-module.exports = ({ total } = { total: process.env.NODE_ENV !== 'production' }) => async (ctx, next) => {
+const doNotConvertMetric = time => time;
+
+module.exports = ({ total, convertMetricUnit } = { total: process.env.NODE_ENV !== 'production', convertMetricUnit: null }) => async (ctx, next) => {
+  if (!convertMetricUnit) {
+    convertMetricUnit = doNotConvertMetric;
+  }
+
   // attaching timings object to state
   ctx.state.timings = {
     all: new Map(),
@@ -36,7 +42,7 @@ module.exports = ({ total } = { total: process.env.NODE_ENV !== 'production' }) 
   // constructing headers array
   const metrics = [];
   for (const [key, { stop: [ sec, nanosec ], desc }] of ctx.state.timings.all) {
-    metrics.push(`${key}=${sec}.${(nanosec / 1000000).toFixed(0).substr(0, 2)}${desc.length && key !== desc ? `; "${desc}"` : ''}`);
+    metrics.push(`${key}=${convertMetricUnit(sec)}.${convertMetricUnit(nanosec / 1000000).toFixed(0).substr(0, 2)}${desc.length && key !== desc ? `; "${desc}"` : ''}`);
   }
 
   // Adding our headers now

--- a/index.test.js
+++ b/index.test.js
@@ -3,41 +3,47 @@ const timings = require('./');
 const route = require('koa-route');
 const request = require('supertest');
 
-const app = new Koa();
+let app;
 
-app.on('error', (err) => {
-  throw err;
-});
+const setupServer = timingsOptions => {
+  app = new Koa();
 
-app.use(timings({ total: true }));
+  app.on('error', (err) => {
+    throw err;
+  });
 
-app.use(route.get('/', async (ctx) => {
-  ctx.body = 'This is test body';
-  // just waiting for 1000 ms
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-}));
+  app.use(timings(timingsOptions));
 
-app.use(route.get('/metric', async (ctx) => {
-  ctx.body = 'This is test body 2';
-  const slug = ctx.state.timings.startSpan('Another 1s task');
-  // just waiting for 1000 ms
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  ctx.state.timings.stopSpan(slug);
-}));
+  app.use(route.get('/', async (ctx) => {
+    ctx.body = 'This is test body';
+    // just waiting for 1000 ms
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }));
 
-app.use(route.get('/badslug', async (ctx) => {
-  ctx.body = 'This is test body 2';
-  const slug = ctx.state.timings.startSpan("This's staff To be Converted to slug");
-  ctx.state.timings.stopSpan(slug);
-}));
+  app.use(route.get('/metric', async (ctx) => {
+    ctx.body = 'This is test body 2';
+    const slug = ctx.state.timings.startSpan('Another 1s task');
+    // just waiting for 1000 ms
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    ctx.state.timings.stopSpan(slug);
+  }));
+
+  app.use(route.get('/badslug', async (ctx) => {
+    ctx.body = 'This is test body 2';
+    const slug = ctx.state.timings.startSpan("This's staff To be Converted to slug");
+    ctx.state.timings.stopSpan(slug);
+  }));
+};
 
 describe('normal requests', () => {
   let server;
   beforeAll(() => {
+    setupServer({ total: true });
     server = app.listen();
   });
 
   afterAll(() => {
+    // reset object
     server.close();
   });
 
@@ -69,6 +75,26 @@ describe('normal requests', () => {
     await request(server)
     .get('/')
     .expect('Server-Timing', /total=1\./)
+    .expect(200)
+    );
+});
+
+describe('convert to ms', () => {
+  let server;
+  beforeAll(() => {
+    setupServer({ total: true, convertMetricUnit: time => time * 1000 });
+    server = app.listen();
+  });
+
+  afterAll(() => {
+    // reset object
+    server.close();
+  });
+
+  test('should return time in milliseconds Server-Timing metrics', async () =>
+    await request(server)
+    .get('/')
+    .expect('Server-Timing', /total=1000\./)
     .expect(200)
     );
 });


### PR DESCRIPTION
Chrome devtools needs milliseconds but not sure why you fixed a bug to move to seconds.

I added this PR so people can choose in what format they want these metrics. Naming could be better though 🙄 

with convertMetricUnit: time => time * 1000
![image](https://user-images.githubusercontent.com/1120926/33202249-2dada7f8-d0fc-11e7-937d-86761f1a0d29.png)

old way:
![image](https://user-images.githubusercontent.com/1120926/33202298-5907557a-d0fc-11e7-9152-c0969727972a.png)


 